### PR TITLE
Add the boolean option to put the host in the subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ The host to send all mail via. Can be any valid format that Exim accepts. e.g. `
 
 The interface to listen on. Defaults to `127.0.0.1`.
 
+####`host_in_subject`
+
+This tells exim to rewrite the subject line so that the sending host is identified at the begining
+of the subject header. 
+
+It rewrites in the form of [$hostname] $Original subject. $hostname is using the factor hostname 
+variable available to puppet.
+
 ## Limitations
 
 This module has only been tested on the following Operating Systems:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class eximsimple (
   $root = $eximsimple::params::root,
   $package_name = $eximsimple::params::package_name,
   $service_name = $eximsimple::params::service_name,
+  $host_in_subject = $eximsimple::params::host_in_subject,
 ) inherits ::eximsimple::params {
 
   package { 'postfix':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class eximsimple::params {
     $domain = 'example.com'
     $local_interfaces = '127.0.0.1'
     $root = 'root@example.com'
+    $host_in_subject = false
 
     case $::osfamily {
       'RedHat': {

--- a/templates/exim.conf.erb
+++ b/templates/exim.conf.erb
@@ -20,6 +20,10 @@ aliasRewrites:
 
 smartHosts:
     driver = manualroute
+    <%- if @host_in_subject -%>
+    headers_remove = subject
+    headers_add = Subject: [<%= @hostname -%>] $h_subject
+    <%- end -%>
     transport = remote_smtp
     route_data = <%= @smarthost %>
 


### PR DESCRIPTION
This change allows you to have the system change the subject line such that the sending host is appended to the current subject. 

This allows you to easily identify which host is sending the email. 

It's default value is false
